### PR TITLE
chore: add compliance team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-* @inworld-ai/devops @inworld-ai/ml @inworld-ai/forward-deploy-engineers
+* @inworld-ai/devops @inworld-ai/ml @inworld-ai/forward-deploy-engineers @inworld-ai/compliance


### PR DESCRIPTION
## Summary
- Add `@inworld-ai/compliance` as a code owner so the compliance team can review and approve changes
- Approval from either the existing team(s) or the compliance team satisfies the code owner requirement
